### PR TITLE
Expose context bindings in Request object

### DIFF
--- a/src/IncomingMessage.js
+++ b/src/IncomingMessage.js
@@ -54,7 +54,8 @@ export default class IncomingMessage extends EventEmitter {
     // Add access specific objects via req.context
     this.context = {
       log           : context.log.bind(context),
-      invocationId  : context.invocationId
+      invocationId  : context.invocationId,
+      bindings      : context.bindings
     };
   }
 


### PR DESCRIPTION
This is a small change that exposes `context.bindings` to the Express handler. This is needed if one wants to use other output bindings than HTTP (e.g. push a message to a storage queue).