### PR TITLE
Extend OutgoingMessage class with native implementation of OutgoingMessage from node http module

### DIFF
--- a/src/OutgoingMessage.js
+++ b/src/OutgoingMessage.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers, no-underscore-dangle */
-import { OutgoingMessage as NativeOutgoingMessage } from http;
+import { OutgoingMessage as NativeOutgoingMessage } from "http";
 import statusCodes from "./statusCodes";
 
 /**
@@ -93,6 +93,7 @@ export default class OutgoingMessage extends NativeOutgoingMessage {
    * Original implementation: https://github.com/nodejs/node/blob/v6.x/lib/_http_outgoing.js#L48
    */
   constructor(context) {
+    super();
     this._headers = null;
     this._headerNames = {};
     this._removedHeader = {};
@@ -103,4 +104,5 @@ export default class OutgoingMessage extends NativeOutgoingMessage {
     this.writeHead = writeHead.bind(this, context);
     this.end = end.bind(this, context);
   }
+
 }

--- a/src/OutgoingMessage.js
+++ b/src/OutgoingMessage.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-magic-numbers, no-underscore-dangle */
+import { OutgoingMessage as NativeOutgoingMessage } from http;
 import statusCodes from "./statusCodes";
 
 /**
@@ -86,7 +87,7 @@ function writeHead(context, statusCode, statusMessage, headers) {
  *
  * @private
  */
-export default class OutgoingMessage {
+export default class OutgoingMessage extends NativeOutgoingMessage {
 
   /**
    * Original implementation: https://github.com/nodejs/node/blob/v6.x/lib/_http_outgoing.js#L48
@@ -102,25 +103,4 @@ export default class OutgoingMessage {
     this.writeHead = writeHead.bind(this, context);
     this.end = end.bind(this, context);
   }
-
-  /**
-   * Original implementation: https://github.com/nodejs/node/blob/v6.x/lib/_http_outgoing.js#L349
-   *
-   * Note: Although express overrides all prototypes, this method still needs to be added because
-   *       express may call setHeader right before overriding prototype (to set "X-Powered-By")
-   *       See https://github.com/expressjs/express/blob/master/lib/middleware/init.js#L23
-   *
-   * @param {string} name
-   * @param {string} value
-   */
-  setHeader(name, value) {
-    if (!this._headers) {
-      this._headers = {};
-    }
-
-    const key = name.toLowerCase();
-    this._headers[key] = value;
-    this._headerNames[key] = name;
-  }
-
 }

--- a/test/ExpressAdapter.test.js
+++ b/test/ExpressAdapter.test.js
@@ -24,7 +24,7 @@ describe("ExpressAdapter", () => {
         // Response that will be sent to Azure Function runtime
         expect(context.res).toEqual({
           body    : "body",
-          headers : undefined,
+          headers : {},
           isRaw   : true,
           status  : 200
         });
@@ -56,7 +56,7 @@ describe("ExpressAdapter", () => {
         // Response that will be sent to Azure Function runtime
         expect(context.res).toEqual({
           body    : "body",
-          headers : undefined,
+          headers : {},
           isRaw   : true,
           status  : 200
         });

--- a/test/ExpressAdapter.test.js
+++ b/test/ExpressAdapter.test.js
@@ -24,7 +24,7 @@ describe("ExpressAdapter", () => {
         // Response that will be sent to Azure Function runtime
         expect(context.res).toEqual({
           body    : "body",
-          headers : {},
+          headers : undefined,
           isRaw   : true,
           status  : 200
         });
@@ -56,7 +56,7 @@ describe("ExpressAdapter", () => {
         // Response that will be sent to Azure Function runtime
         expect(context.res).toEqual({
           body    : "body",
-          headers : {},
+          headers : undefined,
           isRaw   : true,
           status  : 200
         });

--- a/test/OutgoingMessage.test.js
+++ b/test/OutgoingMessage.test.js
@@ -36,7 +36,6 @@ describe("OutgoingMessage", () => {
       const context = { res: {} };
       const res = new OutgoingMessage(context);
       res._headers = { previous: "previous" };
-      res.setHeader = (key, value) => { res._headers[key] = value };
       res._renderHeaders = () => res._headers;
 
       res.writeHead(200, null, { foo: "bar" });


### PR DESCRIPTION
While running express app in the second azure functions runtime I got several errors like: 
```
TypeError: cannot read `content-type` on undefined.
```

In this PR OutgoingMessage inherits methods and properties from node `http` OutgoingMessage module.