### PR TITLE
Relax 'engines' dependency to allow for any version of node past 6.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "validate": "npm run style && npm run coverage"
   },
   "engines": {
-    "node": ">=6.11.2 <7",
+    "node": ">=6.11.2",
     "npm": ">=3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "validate": "npm run style && npm run coverage"
   },
   "engines": {
-    "node": ">=6.11.2",
+    "node": ">=6.11.2 <11",
     "npm": ">=3"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #19 