### PR TITLE
Fix for issue 27 support for log, info,error, warn and verbose methods of context objects 

### DIFF
--- a/src/IncomingMessage.js
+++ b/src/IncomingMessage.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import EventEmitter from "events";
 
-const NOOP = () => {};
+const NOOP = () => { };
 
 function removePortFromAddress(address) {
   return address
@@ -20,8 +20,8 @@ function createConnectionObject(context) {
   const xForwardedFor = req.headers ? req.headers["x-forwarded-for"] : undefined;
 
   return {
-    encrypted     : req.originalUrl && req.originalUrl.toLowerCase().startsWith("https"),
-    remoteAddress : removePortFromAddress(xForwardedFor)
+    encrypted: req.originalUrl && req.originalUrl.toLowerCase().startsWith("https"),
+    remoteAddress: removePortFromAddress(xForwardedFor)
   };
 }
 
@@ -37,14 +37,12 @@ function createConnectionObject(context) {
  */
 function sanitizeContext(context) {
   const sanitizedContext = {
-    ...context,
-    log : context.log.bind(context)
+    ...context
   };
 
   // We don't want the developper to mess up express flow
   // See https://github.com/yvele/azure-function-express/pull/12#issuecomment-336733540
   delete sanitizedContext.done;
-
   return sanitizedContext;
 }
 
@@ -74,6 +72,7 @@ export default class IncomingMessage extends EventEmitter {
     this.connection = createConnectionObject(context);
 
     this.context = sanitizeContext(context); // Specific to Azure Function
+    //this.context = Object.assign(context)
   }
 
 }

--- a/src/IncomingMessage.js
+++ b/src/IncomingMessage.js
@@ -72,7 +72,6 @@ export default class IncomingMessage extends EventEmitter {
     this.connection = createConnectionObject(context);
 
     this.context = sanitizeContext(context); // Specific to Azure Function
-    //this.context = Object.assign(context)
   }
 
 }

--- a/test/ExpressAdapter.test.js
+++ b/test/ExpressAdapter.test.js
@@ -1,7 +1,5 @@
 import { ExpressAdapter } from "../src";
 
-const NOOP = () => {};
-
 describe("ExpressAdapter", () => {
 
   it("Should work", done => {
@@ -16,17 +14,16 @@ describe("ExpressAdapter", () => {
     });
 
     const context = {
-      log       : NOOP,
-      bindings  : { req: { originalUrl: "http://foo.com/bar" } },
-      done      : () => {
+      bindings: { req: { originalUrl: "http://foo.com/bar" } },
+      done: () => {
         expect(listenerCalled).toBe(true);
 
         // Response that will be sent to Azure Function runtime
         expect(context.res).toEqual({
-          body    : "body",
-          headers : {},
-          isRaw   : true,
-          status  : 200
+          body: "body",
+          headers: {},
+          isRaw: true,
+          status: 200
         });
         done();
       }
@@ -48,17 +45,16 @@ describe("ExpressAdapter", () => {
     });
 
     const context = {
-      log       : NOOP,
-      bindings  : { req: { originalUrl: "http://foo.com/bar" } },
-      done      : () => {
+      bindings: { req: { originalUrl: "http://foo.com/bar" } },
+      done: () => {
         expect(listenerCalled).toBe(true);
 
         // Response that will be sent to Azure Function runtime
         expect(context.res).toEqual({
-          body    : "body",
-          headers : {},
-          isRaw   : true,
-          status  : 200
+          body: "body",
+          headers: {},
+          isRaw: true,
+          status: 200
         });
         done();
       }

--- a/test/IncomingMessage.test.js
+++ b/test/IncomingMessage.test.js
@@ -5,13 +5,12 @@ describe("IncomingMessage", () => {
   it("Should work", () => {
 
     const context = {
-      bindings : {
-        req : {
-          originalUrl : "https://foo.com/bar",
-          headers     : { "x-forwarded-for": "192.168.0.1:57996" }
+      bindings: {
+        req: {
+          originalUrl: "https://foo.com/bar",
+          headers: { "x-forwarded-for": "192.168.0.1:57996" }
         }
-      },
-      log : () => {}
+      }
     };
 
     const req = new IncomingMessage(context);
@@ -19,10 +18,10 @@ describe("IncomingMessage", () => {
     req.socket.destroy();
 
     expect(req).toMatchObject({
-      url         : "https://foo.com/bar",
-      connection  : {
-        encrypted     : true,
-        remoteAddress : "192.168.0.1"
+      url: "https://foo.com/bar",
+      connection: {
+        encrypted: true,
+        remoteAddress: "192.168.0.1"
       }
     });
   });
@@ -30,12 +29,11 @@ describe("IncomingMessage", () => {
   it("Should work with no headers", () => {
 
     const context = {
-      bindings : {
-        req : {
-          originalUrl : "http://foo.com/bar"
+      bindings: {
+        req: {
+          originalUrl: "http://foo.com/bar"
         }
-      },
-      log : () => {}
+      }
     };
 
     const req = new IncomingMessage(context);
@@ -43,10 +41,10 @@ describe("IncomingMessage", () => {
     req.socket.destroy();
 
     expect(req).toMatchObject({
-      url         : "http://foo.com/bar",
-      connection  : {
-        encrypted     : false,
-        remoteAddress : undefined
+      url: "http://foo.com/bar",
+      connection: {
+        encrypted: false,
+        remoteAddress: undefined
       }
     });
   });
@@ -54,15 +52,14 @@ describe("IncomingMessage", () => {
   it("Should work with a full native context object", () => {
 
     const context = {
-      invocationId : "f0f6e586-0b79-4407-aa53-97919f45eba5",
-      bindingData : { foo: "bar" },
-      bindings : {
-        req : {
-          originalUrl : "http://foo.com/bar"
+      invocationId: "f0f6e586-0b79-4407-aa53-97919f45eba5",
+      bindingData: { foo: "bar" },
+      bindings: {
+        req: {
+          originalUrl: "http://foo.com/bar"
         }
       },
-      log   : () => {},
-      done  : () => {}
+      done: () => { }
     };
 
     const req = new IncomingMessage(context);
@@ -70,10 +67,10 @@ describe("IncomingMessage", () => {
     req.socket.destroy();
 
     expect(req).toMatchObject({
-      url         : "http://foo.com/bar",
-      connection  : {
-        encrypted     : false,
-        remoteAddress : undefined
+      url: "http://foo.com/bar",
+      connection: {
+        encrypted: false,
+        remoteAddress: undefined
       }
     });
 
@@ -82,8 +79,6 @@ describe("IncomingMessage", () => {
     expect(req.context.invocationId).toBe(context.invocationId);
     expect(req.context.bindingData).toBe(context.bindingData);
     expect(req.context.bindings).toBe(context.bindings);
-    expect(req.context.log).not.toBe(context.log);
-    expect(req.context.log).toBeInstanceOf(Function);
     expect(req.context.done).toBeUndefined(); // We don't want to pass done
 
   });

--- a/test/expressIntegration.test.js
+++ b/test/expressIntegration.test.js
@@ -18,18 +18,17 @@ describe("express integration", () => {
 
     // 3. Mock Azure Function context
     var context = {
-      bindings  : { req: { method: "GET", originalUrl: "https://lol.com/api/foo/bar" } },
-      log       : () => { throw new Error("Log should not be called"); },
-      done : (error) => {
+      bindings: { req: { method: "GET", originalUrl: "https://lol.com/api/foo/bar" } },
+      done: (error) => {
         expect(error).toBeUndefined();
         expect(context.res.status).toBe(200);
         expect(context.res.body).toBe('{"foo":"foo","bar":"bar"}');
         expect(context.res.headers).toEqual({
-          "X-Powered-By"    : "Express",
-          "Cache-Control"   : "max-age=600",
-          "Content-Type"    : "application/json; charset=utf-8",
-          "Content-Length"  : "25",
-          ETag              : 'W/"19-0CKEGOfZ5AYCM4LPaa4gzWL6olU"'
+          "X-Powered-By": "Express",
+          "Cache-Control": "max-age=600",
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Length": "25",
+          ETag: 'W/"19-0CKEGOfZ5AYCM4LPaa4gzWL6olU"'
         });
 
         done();
@@ -55,16 +54,15 @@ describe("express integration", () => {
 
     // 3. Mock Azure Function context
     var context = {
-      bindings  : { req: { method: "GET", originalUrl: "https://lol.com/api/foo/bar" } },
-      log       : () => { throw new Error("Log should not be called"); },
-      done : (error) => {
+      bindings: { req: { method: "GET", originalUrl: "https://lol.com/api/foo/bar" } },
+      done: (error) => {
         expect(error).toBeUndefined();
         expect(context.res.status).toBe(200);
         expect(context.res.body).toBe('{"foo":"foo","bar":"bar"}');
         expect(context.res.headers).toEqual({
-          "Content-Type"    : "application/json; charset=utf-8",
-          "Content-Length"  : "25",
-          ETag              : 'W/"19-0CKEGOfZ5AYCM4LPaa4gzWL6olU"'
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Length": "25",
+          ETag: 'W/"19-0CKEGOfZ5AYCM4LPaa4gzWL6olU"'
         });
 
         done();


### PR DESCRIPTION
#27 Fix for issue 27 support for log, info,error, warn and verbose methods of context objects 

1) Do not add explicit handling for log function in sanitizeContext method
2) remove log related test cases
3) Tested on Azure and now able to log with all the levels specified

![image](https://user-images.githubusercontent.com/15627256/52712993-3b7e4980-2fbc-11e9-9b4d-816228003c6a.png)
