### PR TITLE
Update OutgoingMessage.js

### DIFF
--- a/src/OutgoingMessage.js
+++ b/src/OutgoingMessage.js
@@ -11,7 +11,7 @@ function convertToBody(body, encoding) {
   // This may be removed on Azure Function native support for Buffer
   // https://github.com/Azure/azure-webjobs-sdk-script/issues/814
   // https://github.com/Azure/azure-webjobs-sdk-script/pull/781
-  return Buffer.isBuffer(body)
+  return Buffer.isBuffer(body) && "binary" != encoding
     ? body.toString(encoding)
     : body;
 }


### PR DESCRIPTION
for raw file data download and send

 like below 
if "encoding" value set to "binary" 
then not doing body.toString() in convertToBody function


app.get("/api/getfile", function (req, res) {
	const data = fs.readFileSync("sample.pdf");
	res.writeHead(200, {
		"Content-Type": "application/pdf",
		"Content-Disposition": "attachment;filename=output.pdf"
	});
	res.end(data, "binary");
});