### PR TITLE
Exposing all of context.log

### DIFF
--- a/src/IncomingMessage.js
+++ b/src/IncomingMessage.js
@@ -38,7 +38,7 @@ function createConnectionObject(context) {
 function sanitizeContext(context) {
   const sanitizedContext = {
     ...context,
-    log : context.log.bind(context)
+    log: context.log
   };
 
   // We don't want the developper to mess up express flow


### PR DESCRIPTION
The change allows methods like `context.log.error` to be used.